### PR TITLE
Scale replicas to 2

### DIFF
--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -236,7 +236,7 @@ app "tetris" {
       }
 
       autoscale {
-        min_replicas = 1
+        min_replicas = 2
         max_replicas = 5
         cpu_percent  = 50
       }


### PR DESCRIPTION
We've got multiple I-Piece dependencies and cannot handle the base load with just one replica, Scaling up to two replicas should help out